### PR TITLE
Add a flag to allow auditd configuration to be skipped

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -81,6 +81,8 @@ security_aide_exclude_dirs:
   - /var
 
 ## Audit daemon (auditd)
+# Configure the system using auditd.
+security_rhel7_configure_auditd: yes                         # V-72079
 # Send audit records to a different system using audisp.
 #security_audisp_remote_server: '10.0.21.1'                  # V-72083
 # Encrypt audit records when they are transmitted over the network.

--- a/tasks/rhel7stig/main.yml
+++ b/tasks/rhel7stig/main.yml
@@ -80,7 +80,11 @@
 # Controls by Tag" section of the role documentation.
 - include_tasks: accounts.yml
 - include_tasks: aide.yml
+
 - include_tasks: auditd.yml
+  when:
+    - security_rhel7_configure_auditd | bool
+
 - include_tasks: auth.yml
 - include_tasks: file_perms.yml
 - include_tasks: graphical.yml


### PR DESCRIPTION
This change allows the user to bypass configuration of the OS-provided auditd daemon in situations where an alternative audit daemon is used on a system.